### PR TITLE
Override mavern_artifact module default to use HTTPS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ kafka_connect_service: confluent-kafka-connect
 
 debezium_connector_name: debezium-connector-postgres
 debezium_version: "0.9.5.Final"
+debezium_mavern_url: "https://repo1.maven.org/maven2"
 debezium_app_dir: /opt/debezium
 debezium_jar_file: "{{ debezium_connector_name }}-{{ debezium_version }}.jar"
 debezium_archive: "{{ debezium_connector_name }}-{{ debezium_version }}-plugin.tar.gz"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
 - name: download debezium from mavern central
   maven_artifact:
     group_id: io.debezium
+    repository_url: "{{ debezium_mavern_url }}"
     artifact_id: "{{ debezium_connector_name }}"
     version: "{{ debezium_version }}"
     classifier: plugin


### PR DESCRIPTION
The default uses HTTP, but the endpoint has recently started throwing this error:

`Failed to download artifact io.debezium:debezium-connector-postgres:tar.gz:plugin:0.10.0.Final because of HTTP Error 501: HTTPS Required for URL http://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/0.10.0.Final/debezium-connector-postgres-0.10.0.Final-plugin.tar.gz`

Ansible docs for reference: https://docs.ansible.com/ansible/latest/modules/maven_artifact_module.html#parameter-repository_url